### PR TITLE
fix: transpile syntax incompatible with Hermes

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "ts-jest": "^28.0.7",
     "ts-node": "^10.7.0",
     "typedoc": "^0.23.28",
-    "typescript": "~4.9.5"
+    "typescript": "~5.4.5"
   },
   "packageManager": "yarn@4.1.1",
   "engines": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,14 +4,14 @@
     "exactOptionalPropertyTypes": true,
     "forceConsistentCasingInFileNames": true,
     // Reminder: Remove custom `cause` field from JsonRpcError when enabling es2022
-    "lib": ["ES2020"],
+    "lib": ["ES2020", "ES2015"],
     "module": "CommonJS",
     "moduleResolution": "node",
     "noEmit": true,
     "noErrorTruncation": true,
     "noUncheckedIndexedAccess": true,
     "strict": true,
-    "target": "es2020"
+    "target": "es5"
   },
   "exclude": ["./dist", "**/node_modules"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "exactOptionalPropertyTypes": true,
     "forceConsistentCasingInFileNames": true,
     // Reminder: Remove custom `cause` field from JsonRpcError when enabling es2022
-    "lib": ["ES2020", "ES2015"],
+    "lib": ["es6", "ES2020", "ES2015"],
     "module": "CommonJS",
     "moduleResolution": "node",
     "noEmit": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1039,7 +1039,7 @@ __metadata:
     ts-jest: "npm:^28.0.7"
     ts-node: "npm:^10.7.0"
     typedoc: "npm:^0.23.28"
-    typescript: "npm:~4.9.5"
+    typescript: "npm:~5.4.5"
   languageName: unknown
   linkType: soft
 
@@ -6958,23 +6958,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:~4.9.5":
-  version: 4.9.5
-  resolution: "typescript@npm:4.9.5"
+"typescript@npm:~5.4.5":
+  version: 5.4.5
+  resolution: "typescript@npm:5.4.5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/458f7220ab11e0fc191514cc41be1707645ec9a8c2d609448a448e18c522cef9646f58728f6811185a4c35613dacdf6c98cf8965c88b3541d0288c47291e4300
+  checksum: 10/d04a9e27e6d83861f2126665aa8d84847e8ebabcea9125b9ebc30370b98cb38b5dff2508d74e2326a744938191a83a69aa9fddab41f193ffa43eabfdf3f190a5
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A~4.9.5#optional!builtin<compat/typescript>":
-  version: 4.9.5
-  resolution: "typescript@patch:typescript@npm%3A4.9.5#optional!builtin<compat/typescript>::version=4.9.5&hash=289587"
+"typescript@patch:typescript@npm%3A~5.4.5#optional!builtin<compat/typescript>":
+  version: 5.4.5
+  resolution: "typescript@patch:typescript@npm%3A5.4.5#optional!builtin<compat/typescript>::version=5.4.5&hash=5adc0c"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/5659316360b5cc2d6f5931b346401fa534107b68b60179cf14970e27978f0936c1d5c46f4b5b8175f8cba0430f522b3ce355b4b724c0ea36ce6c0347fab25afd
+  checksum: 10/760f7d92fb383dbf7dee2443bf902f4365db2117f96f875cf809167f6103d55064de973db9f78fe8f31ec08fff52b2c969aee0d310939c0a3798ec75d0bca2e1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The migration to ts-bridge introduced `class ... extends` syntax in the bundle, which is not supported by the version of Hermes used in metamask-mobile.

While we could reasonably argue that this should be solved in the downstream build, here is a fix which restores compatibility by increasing typescript transpilation.
